### PR TITLE
Fix Images without dimensions

### DIFF
--- a/api/components/Person.js
+++ b/api/components/Person.js
@@ -10,7 +10,7 @@ const Person = ({ person }) => (
   <Card className="person">
     <div className="person">
       <a href="https://github.com/devarthurribeiro">
-        <img src={person.img} alt="Arthur Ribeiro" />
+        <img src={person.img} width="160" height="160"  alt="Arthur Ribeiro" />
       </a>
       <h3>{person.name}</h3>
       <span>{person.role}</span>


### PR DESCRIPTION
include width and height size attributes on you images  Alternatively, reserve the required space with [CSS aspect ratio boxes](https://css-tricks.com/aspect-ratio-boxes/). This approach ensures that the browser can allocate the correct amount of space in the document while the image is loading.
Modern browsers now set the default aspect ratio of images based on an image's width and height attributes so it's valuable to set them to prevent layout shifts. Thanks to the CSS Working Group, developers just need to set width and height as normal.